### PR TITLE
Add meta-based quiz resolution helpers

### DIFF
--- a/emails/first-quiz-email.php
+++ b/emails/first-quiz-email.php
@@ -82,13 +82,21 @@ function pqc_get_first_quiz_email_content( $quiz_data, $user ) {
     $chart_url_avg   = politeia_generate_quickchart_url( $avg_score );
     $quiz_id         = isset( $quiz_data['quiz'] ) ? intval( $quiz_data['quiz'] ) : 0;
 
-    $course_id = $wpdb->get_var( $wpdb->prepare( "
-        SELECT post_id
-        FROM {$wpdb->postmeta}
-        WHERE meta_key = '_first_quiz_id'
-          AND meta_value = %d
-        LIMIT 1
-    ", $quiz_id ) );
+    $analytics = class_exists( 'Politeia_Quiz_Analytics' )
+        ? new Politeia_Quiz_Analytics( (int) $quiz_id )
+        : null;
+
+    if ( $analytics ) {
+        $course_id = $analytics->getCourseId();
+    } else {
+        $course_id = $wpdb->get_var( $wpdb->prepare( "
+            SELECT post_id
+            FROM {$wpdb->postmeta}
+            WHERE meta_key = '_first_quiz_id'
+              AND meta_value = %d
+            LIMIT 1
+        ", $quiz_id ) );
+    }
 
     $course_title = get_the_title( $course_id );
     $course_url   = $course_id ? get_permalink( $course_id ) : home_url();

--- a/overrides/learndash/ld30/modules/infobar/course.php
+++ b/overrides/learndash/ld30/modules/infobar/course.php
@@ -91,7 +91,9 @@ $prog = learndash_course_progress( array(
 $all_done = isset( $prog['completed'], $prog['total'] ) && ( (int) $prog['completed'] >= (int) $prog['total'] );
 
 // 3) Recuperar ID de Final Quiz y sus intentos
-$final_quiz_id = get_post_meta( $course_id, '_final_quiz_id', true );
+$final_quiz_id = class_exists( 'PoliteiaCourse' )
+    ? PoliteiaCourse::getFinalQuizId( (int) $course_id )
+    : (int) get_post_meta( $course_id, '_final_quiz_id', true );
 $attempts      = array();
 if ( $final_quiz_id ) {
     $attempts = learndash_get_user_quiz_attempts( $user_id, $final_quiz_id );

--- a/overrides/learndash/ld30/template-single-course-sidebar.php
+++ b/overrides/learndash/ld30/template-single-course-sidebar.php
@@ -187,8 +187,12 @@ if ( 0 < $progress['percentage'] && 100 !== $progress['percentage'] ) {
                     // ——— START CUSTOM BUTTON LOGIC (BASED ON DIAGRAM AND CLARIFICATIONS) ———
 
                     // IDs básicos para Quizzes
-                    $first_quiz_id = get_post_meta( $course_id, '_first_quiz_id', true );
-                    $final_quiz_id = get_post_meta( $course_id, '_final_quiz_id', true );
+                    $first_quiz_id = class_exists( 'PoliteiaCourse' )
+                        ? PoliteiaCourse::getFirstQuizId( (int) $course_id )
+                        : (int) get_post_meta( $course_id, '_first_quiz_id', true );
+                    $final_quiz_id = class_exists( 'PoliteiaCourse' )
+                        ? PoliteiaCourse::getFinalQuizId( (int) $course_id )
+                        : (int) get_post_meta( $course_id, '_final_quiz_id', true );
 
                     // URLs para Quizzes
                     $first_quiz_url = $first_quiz_id


### PR DESCRIPTION
## Summary
- add reusable course helpers for resolving first and final quiz IDs from metadata and expose a quiz analytics helper
- refactor course, email, and template logic to rely on the new helpers instead of scanning LearnDash step tables
- update front-end gating, sidebar buttons, and debug messaging to gracefully handle missing quiz metadata

## Testing
- php -l emails.php
- php -l emails/first-quiz-email.php
- php -l functions.php
- php -l includes/class-politeia-quiz-stats.php
- php -l overrides/learndash/ld30/modules/infobar/course.php
- php -l overrides/learndash/ld30/template-single-course-sidebar.php
- php -l overrides/quiz/partials/show_quiz_result_box.php
- php -l templates/quiz/single-sfwd-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68df29175b0c8332960ab87b77ba4e6b