### PR TITLE
Restrict course editor to page tab

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -24,4 +24,19 @@
   .select2-selection--single {
     height: 32px;
   }
+
+  /* Mostrar el editor de bloques sólo en la pestaña "Página Curso" */
+  body.post-type-sfwd-courses.pqc-course-page-tab-hidden #editor,
+  body.post-type-sfwd-courses.pqc-course-page-tab-hidden .interface-interface-skeleton,
+  body.post-type-sfwd-courses.pqc-course-page-tab-hidden #postdivrich {
+    display: none !important;
+  }
+
+  body.post-type-sfwd-courses.pqc-course-page-tab-hidden .editor-post-title__block,
+  body.post-type-sfwd-courses.pqc-course-page-tab-hidden .edit-post-header,
+  body.post-type-sfwd-courses.pqc-course-page-tab-hidden .edit-post-sidebar,
+  body.post-type-sfwd-courses.pqc-course-page-tab-hidden .interface-interface-skeleton__sidebar,
+  body.post-type-sfwd-courses.pqc-course-page-tab-hidden .edit-post-layout {
+    display: none !important;
+  }
   

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -60,6 +60,92 @@
         }
       });
     });
-  
+
+    $(function () {
+      const $body = $('body');
+
+      if ( !$body.hasClass('post-type-sfwd-courses') ) {
+        return;
+      }
+
+      const $editor = $('#editor');
+      const $classicEditor = $('#postdivrich');
+      const $editorContainer = $editor.length ? $editor : $classicEditor;
+
+      if ( !$editorContainer.length ) {
+        return;
+      }
+
+      const $tabs = $('.learndash-tabs__tab, .ld-tabs__tab, [data-tab-target], [data-tab_target], [data-target]');
+
+      if ( !$tabs.length ) {
+        return;
+      }
+
+      const COURSE_PAGE_LABELS = [
+        'página curso',
+        'pagina curso',
+        'course page',
+        'course content',
+        'página del curso',
+      ];
+
+      function isCoursePageTab( $tab ) {
+        if ( !$tab || !$tab.length ) {
+          return false;
+        }
+
+        const dataTarget = $tab.data('tabTarget')
+          || $tab.data('tab-target')
+          || $tab.data('tab_target')
+          || $tab.attr('data-target')
+          || '';
+
+        if ( dataTarget && /course[-_]?page|ld-course-page|course[-_]?content/i.test( dataTarget ) ) {
+          return true;
+        }
+
+        const label = $.trim( $tab.text() ).toLowerCase();
+
+        return COURSE_PAGE_LABELS.includes( label );
+      }
+
+      function getActiveTab() {
+        return $tabs.filter(function () {
+          const $tab = $(this);
+          return $tab.hasClass('is-active')
+            || $tab.hasClass('learndash-tabs__tab--active')
+            || $tab.hasClass('ld-tabs__tab--active')
+            || $tab.attr('aria-selected') === 'true';
+        }).first();
+      }
+
+      function toggleEditorVisibility() {
+        const $active = getActiveTab();
+        const isCoursePageActive = isCoursePageTab( $active );
+
+        $body.toggleClass('pqc-course-page-tab-active', isCoursePageActive);
+        $body.toggleClass('pqc-course-page-tab-hidden', ! isCoursePageActive );
+      }
+
+      toggleEditorVisibility();
+
+      $tabs.on('click', function () {
+        window.setTimeout( toggleEditorVisibility, 25 );
+      });
+
+      if ( 'MutationObserver' in window ) {
+        const observer = new MutationObserver( toggleEditorVisibility );
+        $tabs.each(function ( index, element ) {
+          observer.observe( element, {
+            attributes: true,
+            attributeFilter: [ 'class', 'aria-selected' ],
+          } );
+        });
+      }
+
+      window.setTimeout( toggleEditorVisibility, 250 );
+    });
+
   })(jQuery);
   


### PR DESCRIPTION
## Summary
- add admin-side javascript that tracks LearnDash course tabs and toggles the block editor visibility
- hide the Gutenberg interface with targeted admin css when the course page tab is not active

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfb2f70e908332a939ff5415389ad7